### PR TITLE
modify: API 호출 통일화, 화폐 선택 시 이전 계산 결과 메시지 숨김 [#3]

### DIFF
--- a/src/pages/simple-calc/index.js
+++ b/src/pages/simple-calc/index.js
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
-import axios from 'axios';
 import styled from 'styled-components';
+import API from 'utils/api';
+import { SIMPLE_CURRENCY_LIST } from 'utils/currency';
 
 // styled components
 const StyledContainer = styled.main`
@@ -69,11 +70,6 @@ const ErrorMessage = styled.p`
 `;
 
 // constants
-const CURRENCY_LIST = [
-  { currency: 'KRW', country: '한국' },
-  { currency: 'JPY', country: '일본' },
-  { currency: 'PHP', country: '필리핀' },
-];
 const CALCULATOR_TITLE = '환율 계산';
 const SENDER_LABEL = '송금국가';
 const SENDER_COUNTRY = '미국';
@@ -81,7 +77,6 @@ const SENDER_CURRENCY = 'USD';
 const RECIPIENT_LABEL = '수취국가';
 const CURRENCY_LABEL = '환율';
 const ERROR_MESSAGE = '송금액이 바르지 않습니다';
-const API_LINK = `http://www.apilayer.net/api/live?access_key=${process.env.REACT_APP_CURRENCY_KEY}`;
 
 const formatNumber = num => {
   if (typeof num !== 'number') return null;
@@ -109,16 +104,22 @@ function SimpleCalc() {
   const [result, setResult] = useState(0);
 
   useEffect(() => {
-    axios
-      .get(API_LINK)
-      .then(res => {
-        const data = res.data.quotes[`USD${currency}`];
-        setRate(formatNumber(data));
-      })
-      .catch();
+    const getRates = async () => {
+      try {
+        const res = await API.get(
+          `live?access_key=${process.env.REACT_APP_CURRENCY_KEY}`,
+        );
+        const quote = res.data.quotes[`USD${currency}`];
+        setRate(formatNumber(quote));
+      } catch (e) {
+        console.log(e);
+      }
+    };
+    getRates();
   }, [currency]);
 
   const handleSelect = e => {
+    if (showMessage) setShowMessage(prev => !prev);
     setCurrency(e.target.value);
   };
 
@@ -163,7 +164,7 @@ function SimpleCalc() {
               name="currency"
               id="currency-box"
               onChange={handleSelect}>
-              {CURRENCY_LIST.map(({ currency: c, country }) => (
+              {SIMPLE_CURRENCY_LIST.map(({ currency: c, country }) => (
                 <option value={c} key={c}>{`${country}(${c})`}</option>
               ))}
             </StyledSelect>

--- a/src/utils/currency.js
+++ b/src/utils/currency.js
@@ -1,4 +1,10 @@
 const TAB_CURRENCY = ['USD', 'CAD', 'KRW', 'HKD', 'JPY', 'CNY'];
 const SIMPLE_CURRENCY = ['USD', 'CAD', 'KRW', 'HKD', 'JPY', 'CNY'];
 
-export { TAB_CURRENCY, SIMPLE_CURRENCY };
+const SIMPLE_CURRENCY_LIST = [
+  { currency: 'KRW', country: '한국' },
+  { currency: 'JPY', country: '일본' },
+  { currency: 'PHP', country: '필리핀' },
+];
+
+export { TAB_CURRENCY, SIMPLE_CURRENCY, SIMPLE_CURRENCY_LIST };


### PR DESCRIPTION
## 타입

- [ ] Bugfix
- [ ] Feature
- [x] Refactoring
- [ ] Other

## 구현사항
- 탭 계산기와 API 호출 방식 통일화
- 화폐 선택 시 이전 계산 결과 메시지 숨김
- utils 폴더에 SIMPLE_CURRENCY_LIST 생성

## 체크리스트

- [x] Linked Issues에서 적절한 이슈 하나를 걸어두었습니다.
- [x] 의도한 파일들과 수정 사항들만 커밋이 된 것을 확인 하였습니다.
- [x] 기능이 제대로 실행되는지 확인 하였습니다.
- [x] npm start로 구현한 화면 혹은 기능을 확인할 수 있습니다.

## 특이 사항
